### PR TITLE
Fix(auth): Decrypt password for web client

### DIFF
--- a/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/oauth2/customlogin/service/AuthenticationService.java
+++ b/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/oauth2/customlogin/service/AuthenticationService.java
@@ -20,7 +20,7 @@ public class AuthenticationService {
 
 	public Authentication authenticate(LoginRequest loginRequest, String clientType) {
 		String password = loginRequest.getPassword();
-		if ("angular".equalsIgnoreCase(clientType)) {
+		if ("angular".equalsIgnoreCase(clientType) || "web".equalsIgnoreCase(clientType)) {
 			password = AESUtil.decrypt(password);
 		}
 		return authenticationManager


### PR DESCRIPTION
The login process was failing for web clients because the password was not being decrypted before being passed to the authentication manager. This was because the `AuthenticationService` only decrypted passwords for the "angular" client type.

This change modifies the `AuthenticationService` to also decrypt the password for the "web" client type, which resolves the issue.