### PR TITLE
Fix: Use opaque token introspection for resource server

### DIFF
--- a/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
+++ b/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.anyRequest().authenticated()
 			)
-			.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+			.oauth2ResourceServer(oauth2 -> oauth2.opaqueToken(Customizer.withDefaults()))
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.csrf(csrf -> csrf.disable());
 		return http.build();


### PR DESCRIPTION
The resource server was configured to use JWT validation, but the authorization server is issuing opaque access tokens. This caused a 401 Unauthorized error even with a valid token.

This commit changes the resource server configuration to use opaque token introspection, which will correctly validate the access tokens.