### PR TITLE
This commit includes several fixes to the authentication and authoriz…

### DIFF
--- a/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/handler/CustomAuthenticationEntryPoint.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
@@ -68,6 +69,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                 || authException instanceof UsernameNotFoundException) {
             errorCode = ErrorCodes.INVALID_CREDENTIALS;
             message = "Invalid username or password";
+        } else if (authException instanceof OAuth2AuthenticationException) {
+            errorCode = ErrorCodes.INVALID_TOKEN;
+            message = authException.getMessage();
         } else {
             errorCode = ErrorCodes.INVALID_TOKEN;
             message = "Access token is invalid or expired";


### PR DESCRIPTION
…ation process.

1.  **Fix Deserialization Error:** A `java.lang.IllegalArgumentException` was being thrown during token introspection because `java.lang.Long` was not on the Jackson deserialization allowlist. This was fixed by vendoring `JdbcOAuth2AuthorizationService` into `CustomOAuth2AuthorizationService` and modifying the internal `ObjectMapper` to add `Long`, `Double`, and `HashSet` to the allowlist.

2.  **Reuse Active Tokens:** The `/api/auth/login` endpoint was generating a new access token on every call. This is fixed by modifying the login logic to check for an existing, active authorization for the user and return it if found.

3.  **Improve Error Handling:** The error response for invalid or missing tokens has been improved to provide a more specific message, in line with the application's existing error handling standards.

4.  **Correct Token Introspection:** The resource server is now correctly configured to use opaque token introspection.