### PR TITLE
feat: Update authentication endpoints

### DIFF
--- a/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
+++ b/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(2)
-	SecurityFilterChain resourceServerSecurityFilterChain(HttpSecurity http) throws Exception {
+	SecurityFilterChain resourceServerSecurityFilterChain(HttpSecurity http,
+			CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
 		http
 			.securityMatcher("/api/**", "/email-verifier/**")
 			.authorizeHttpRequests(authorize -> authorize
@@ -76,6 +77,7 @@ public class SecurityConfig {
 			)
 			.oauth2ResourceServer(oauth2 -> oauth2.opaqueToken(Customizer.withDefaults()))
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(eh -> eh.authenticationEntryPoint(customAuthenticationEntryPoint))
 			.csrf(csrf -> csrf.disable());
 		return http.build();
 	}


### PR DESCRIPTION
- Increase access token expiration to 3 days
- Add user object to login response
- Remove duplicate /auth/token endpoint
- Move /auth/refresh endpoint to AuthController

fix: Use UserRepository to fetch user profile

- The previous implementation used a non-existent method `findProfileByEmail` in `UserService`.
- This has been corrected to use `UserRepository.findByEmail` to fetch the user and construct the user profile.

fix: Add custom authentication entry point to resource server

- The resource server security filter chain was not configured with the custom authentication entry point.
- This resulted in incorrect error responses for invalid or expired tokens.
- The custom authentication entry point has been added to the resource server security filter chain to ensure proper error responses.