### PR TITLE
Fix timezone issue in account activation token expiration

### DIFF
--- a/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/UserActivationHistory.java
+++ b/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/UserActivationHistory.java
@@ -1,6 +1,6 @@
 package com.xtremand.domain.entity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import com.xtremand.domain.enums.ActivationStatus;
 
@@ -44,10 +44,10 @@ public class UserActivationHistory extends BaseEntity {
     private String activationToken;
 
     @Column(name = "requested_at", nullable = false)
-    private LocalDateTime requestedAt;
+    private Instant requestedAt;
 
     @Column(name = "activated_at")
-    private LocalDateTime activatedAt;
+    private Instant activatedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/xtremand-backend/xtremand-user/src/main/java/com/xtremand/user/service/ActivationServiceImpl.java
+++ b/xtremand-backend/xtremand-user/src/main/java/com/xtremand/user/service/ActivationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.xtremand.user.service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -40,7 +41,7 @@ public class ActivationServiceImpl implements ActivationService {
         UserActivationHistory history = UserActivationHistory.builder()
                 .user(user)
                 .activationToken(token)
-                .requestedAt(LocalDateTime.now())
+                .requestedAt(Instant.now())
                 .status(ActivationStatus.PENDING)
                 .build();
         userActivationHistoryRepository.save(history);
@@ -59,7 +60,7 @@ public class ActivationServiceImpl implements ActivationService {
             throw new IllegalStateException("Account already activated");
         }
 
-        if (history.getRequestedAt().plusHours(activationTokenExpiryInHours).isBefore(LocalDateTime.now())) {
+        if (history.getRequestedAt().plus(activationTokenExpiryInHours, ChronoUnit.HOURS).isBefore(Instant.now())) {
             history.setStatus(ActivationStatus.EXPIRED);
             userActivationHistoryRepository.save(history);
             throw new IllegalStateException("Activation token expired");
@@ -69,7 +70,7 @@ public class ActivationServiceImpl implements ActivationService {
         user.setStatus(UserStatus.ACTIVE);
         userRepository.save(user);
 
-        history.setActivatedAt(LocalDateTime.now());
+        history.setActivatedAt(Instant.now());
         history.setStatus(ActivationStatus.COMPLETED);
         userActivationHistoryRepository.save(history);
     }


### PR DESCRIPTION
The account activation token was using `LocalDateTime` for its expiration check. `LocalDateTime` is not timezone-aware, which can cause issues when the server, database, or user are in different timezones. This could lead to tokens expiring incorrectly.

This commit replaces `LocalDateTime` with `java.time.Instant` for all timestamp-related operations in the account activation flow. `Instant` represents a specific point in time on the UTC timeline and is the standard for handling timestamps across different timezones, making the token expiration logic more robust and reliable.