### PR TITLE
fix(auth): Disable CSRF for forgot-password and refresh endpoints

### DIFF
--- a/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
+++ b/xtremand-backend/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig {
 				.authenticationEntryPoint(customAuthenticationEntryPoint)
 				.accessDeniedHandler(customAccessDeniedHandler)
 			)
-			.csrf(csrf -> csrf.ignoringRequestMatchers("/auth/signup", "/auth/login"));
+			.csrf(csrf -> csrf.ignoringRequestMatchers("/auth/signup", "/auth/login", "/auth/forgot-password", "/auth/refresh"));
 		return http.build();
 	}
 


### PR DESCRIPTION
The /auth/forgot-password and /auth/refresh endpoints were inaccessible due to InvalidCsrfTokenException. This was because they were not excluded from CSRF protection.

This commit updates the SecurityConfig to also ignore CSRF for these two endpoints, aligning them with the other public-facing authentication endpoints like /auth/login and /auth/signup.