### PR TITLE
feat: Change user_id in EmailVerificationBatch to a foreign key

### DIFF
--- a/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailVerificationBatch.java
+++ b/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailVerificationBatch.java
@@ -10,8 +10,11 @@ import org.hibernate.annotations.CreationTimestamp;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,8 +32,9 @@ public class EmailVerificationBatch {
 	@Column(name = "id", updatable = false, nullable = false)
 	private UUID id;
 
-	@Column(name = "user_id", nullable = false)
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 	@CreationTimestamp
 	@Column(name = "created_at", updatable = false)

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/model/mapper/BatchResultMapper.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/model/mapper/BatchResultMapper.java
@@ -14,7 +14,7 @@ import com.xtremand.email.verification.repository.EmailVerificationHistoryReposi
 public interface BatchResultMapper {
 
 	@Mapping(source = "id", target = "batchId")
-	@Mapping(source = "userId", target = "userId")
+	@Mapping(source = "user.id", target = "userId")
 	EmailVerificationBatchDto toBatchDto(EmailVerificationBatch entity);
 
 	@Mapping(source = "id", target = "batchId")

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/repository/EmailVerificationBatchRepository.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/repository/EmailVerificationBatchRepository.java
@@ -11,6 +11,6 @@ import java.util.UUID;
 
 @Repository
 public interface EmailVerificationBatchRepository extends JpaRepository<EmailVerificationBatch, UUID> {
-    Page<EmailVerificationBatch> findByUserId(Long userId, Pageable pageable);
-    Optional<EmailVerificationBatch> findByIdAndUserId(UUID id, Long userId);
+    Page<EmailVerificationBatch> findByUser_Id(Long userId, Pageable pageable);
+    Optional<EmailVerificationBatch> findByIdAndUser_Id(UUID id, Long userId);
 }

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationService.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationService.java
@@ -43,7 +43,7 @@ public class EmailVerificationService {
 
 	@Transactional
 	public VerificationResult verifyEmail(String email, EmailVerificationBatch batch) {
-		Long userId = (batch != null) ? batch.getUserId() : userIdentityService.getRequiredUserId();
+		Long userId = (batch != null) ? batch.getUser().getId() : userIdentityService.getRequiredUserId();
 		User user = userRepository.findById(userId)
 				.orElseThrow(() -> new IllegalStateException("User not found for ID: " + userId));
 

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/ReportingService.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/ReportingService.java
@@ -33,14 +33,14 @@ public class ReportingService {
 
     public Page<EmailVerificationBatchDto> getBatchSummaries(Pageable pageable) {
         Long userId = userIdentityService.getRequiredUserId();
-        return batchRepository.findByUserId(userId, pageable)
+        return batchRepository.findByUser_Id(userId, pageable)
                 .map(batchResultMapper::toBatchDto);
     }
 
     public Page<VerifyEmailResponse> getBatchEmails(UUID batchId, Pageable pageable) {
         Long userId = userIdentityService.getRequiredUserId();
         // First, verify that the batch belongs to the user to prevent data leakage
-        batchRepository.findByIdAndUserId(batchId, userId)
+        batchRepository.findByIdAndUser_Id(batchId, userId)
                 .orElseThrow(() -> new AccessDeniedException("Access denied to batch " + batchId));
 
         return historyRepository.findByBatchIdAndUser_Id(batchId, userId, pageable)

--- a/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/controller/EmailVerificationControllerUserITest.java
+++ b/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/controller/EmailVerificationControllerUserITest.java
@@ -76,7 +76,7 @@ class EmailVerificationControllerUserITest {
     private void createTestData() {
         // User A's data
         EmailVerificationBatch batchA = new EmailVerificationBatch();
-        batchA.setUserId(userA.getId());
+        batchA.setUser(userA);
         batchA.setTotalEmails(1);
         batchRepository.save(batchA);
 
@@ -92,7 +92,7 @@ class EmailVerificationControllerUserITest {
 
         // User B's data
         EmailVerificationBatch batchB = new EmailVerificationBatch();
-        batchB.setUserId(userB.getId());
+        batchB.setUser(userB);
         batchB.setTotalEmails(1);
         batchRepository.save(batchB);
 
@@ -121,7 +121,7 @@ class EmailVerificationControllerUserITest {
     @Test
     void getBatchEmails_asUserAForUserBBatch_shouldReturnAccessDenied() throws Exception {
         createTestData();
-        EmailVerificationBatch batchB = batchRepository.findByUserId(userB.getId(), org.springframework.data.domain.Pageable.unpaged()).getContent().get(0);
+        EmailVerificationBatch batchB = batchRepository.findByUser_Id(userB.getId(), org.springframework.data.domain.Pageable.unpaged()).getContent().get(0);
 
         mockMvc.perform(get("/api/v1/email/verify/batch/{batchId}/emails", batchB.getId())
                         .with(jwt().jwt(j -> j.claim("user_id", userA.getId()))))

--- a/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/service/ReportingServiceTest.java
+++ b/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/service/ReportingServiceTest.java
@@ -67,7 +67,7 @@ class ReportingServiceTest {
         Page<EmailVerificationBatch> page = new PageImpl<>(Collections.singletonList(batch));
         EmailVerificationBatchDto dto = EmailVerificationBatchDto.builder().build();
 
-        when(batchRepository.findByUserId(testUserId, pageable)).thenReturn(page);
+        when(batchRepository.findByUser_Id(testUserId, pageable)).thenReturn(page);
         when(batchResultMapper.toBatchDto(any(EmailVerificationBatch.class))).thenReturn(dto);
 
         // When
@@ -86,7 +86,7 @@ class ReportingServiceTest {
         Page<EmailVerificationHistory> page = new PageImpl<>(Collections.singletonList(history));
         VerifyEmailResponse dto = new VerifyEmailResponse();
 
-        when(batchRepository.findByIdAndUserId(batchId, testUserId)).thenReturn(Optional.of(new EmailVerificationBatch()));
+        when(batchRepository.findByIdAndUser_Id(batchId, testUserId)).thenReturn(Optional.of(new EmailVerificationBatch()));
         when(historyRepository.findByBatchIdAndUser_Id(batchId, testUserId, pageable)).thenReturn(page);
         when(emailVerificationMapper.toDto(any(EmailVerificationHistory.class))).thenReturn(dto);
 


### PR DESCRIPTION
Changed the `user_id` in the `EmailVerificationBatch` table to a foreign key referencing the `User` entity.

This change involved:
- Modifying the `EmailVerificationBatch` entity to use a `@ManyToOne` relationship with the `User` entity.
- Updating the `EmailVerificationBatchRepository` to query by `user.id`.
- Updating the `BatchVerificationService`, `EmailVerificationService`, and `ReportingService` to work with the new `User` object relationship.
- Updating the `BatchResultMapper` to correctly map `user.id` to `userId` in the DTO.
- Updating unit and integration tests to reflect the changes.