### PR TITLE
feat: Add contact foreign key to email verification history

### DIFF
--- a/xtremand-backend/xtremand-app/src/main/resources/db/migration/V2__add_contact_id_to_email_verification_history.sql
+++ b/xtremand-backend/xtremand-app/src/main/resources/db/migration/V2__add_contact_id_to_email_verification_history.sql
@@ -1,0 +1,7 @@
+ALTER TABLE xt_user_email_verification_history
+ADD COLUMN contact_id BIGINT;
+
+ALTER TABLE xt_user_email_verification_history
+ADD CONSTRAINT fk_email_verification_history_contact
+FOREIGN KEY (contact_id)
+REFERENCES xt_contacts(id);

--- a/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailVerificationHistory.java
+++ b/xtremand-backend/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailVerificationHistory.java
@@ -109,6 +109,11 @@ public class EmailVerificationHistory {
 	@Column(name = "checked_at", updatable = false)
 	private Instant checkedAt;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "contact_id")
+	@ToString.Exclude
+	private Contact contact;
+
 	public enum VerificationStatus {
 		VALID, INVALID, RISKY, UNKNOWN, DISPOSABLE, BLACKLISTED
 	}

--- a/xtremand-backend/xtremand-email-verification/pom.xml
+++ b/xtremand-backend/xtremand-email-verification/pom.xml
@@ -51,6 +51,10 @@
             <groupId>com.xtremand</groupId>
             <artifactId>xtremand-user</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.xtremand</groupId>
+            <artifactId>xtremand-contact</artifactId>
+        </dependency>
         <!-- Email & Network Utilities -->
         <dependency>
             <groupId>commons-validator</groupId>

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationService.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationService.java
@@ -1,5 +1,7 @@
 package com.xtremand.email.verification.service;
 
+import com.xtremand.contact.repository.ContactRepository;
+import com.xtremand.domain.entity.Contact;
 import com.xtremand.domain.entity.EmailVerificationBatch;
 import com.xtremand.domain.entity.EmailVerificationHistory;
 import com.xtremand.domain.entity.User;
@@ -36,6 +38,7 @@ public class EmailVerificationService {
 	private final ScoringProperties scoringProperties;
 	private final EmailVerificationHistoryRepository historyRepository;
 	private final UserRepository userRepository;
+	private final ContactRepository contactRepository;
 
 	@Transactional
 	public VerificationResult verifyEmail(String email) {
@@ -174,6 +177,13 @@ public class EmailVerificationService {
 		EmailVerificationHistory history = new EmailVerificationHistory();
 		history.setUser(user);
 		history.setEmail(result.getEmail());
+
+		// Find and set the contact if it exists
+		Contact contact = contactRepository.findByEmailIgnoreCase(result.getEmail());
+		if (contact != null) {
+			history.setContact(contact);
+		}
+
 		history.setDomain(domain);
 		history.setBatch(batch);
 		history.setStatus(result.getStatus());


### PR DESCRIPTION
Adds a `contact_id` foreign key to the `xt_user_email_verification_history` table.

When an email is verified, the system now checks if a contact with the same email exists. If a contact is found, its ID is stored in the new `contact_id` column of the email verification history record.

This change includes:
- A Flyway migration script to update the database schema.
- An update to the `EmailVerificationHistory` entity to include the new relationship.
- A modification to the `EmailVerificationService` to populate the new column.