### PR TITLE
fix: Validate range value for dropdown

### DIFF
--- a/xtremand-backend/xtremand-common/src/main/java/com/xtremand/common/exception/GlobalExceptionHandler.java
+++ b/xtremand-backend/xtremand-common/src/main/java/com/xtremand/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.xtremand.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.Collections;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String errorMessage = "Invalid value for parameter.";
+        if (ex.getCause() instanceof IllegalArgumentException) {
+            errorMessage = ex.getCause().getMessage();
+        }
+        return new ResponseEntity<>(Collections.singletonMap("error", errorMessage), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequestException(BadRequestException ex) {
+        return new ResponseEntity<>(Collections.singletonMap("error", ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/converter/ChartRangeConverter.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/converter/ChartRangeConverter.java
@@ -1,0 +1,19 @@
+package com.xtremand.email.verification.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.xtremand.email.verification.model.dto.chart.ChartRange;
+
+@Component
+public class ChartRangeConverter implements Converter<String, ChartRange> {
+
+    @Override
+    public ChartRange convert(String source) {
+        try {
+            return ChartRange.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid range value. Allowed values are: M1, M3, M6, Y1, Y3, Y5");
+        }
+    }
+}

--- a/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationChartService.java
+++ b/xtremand-backend/xtremand-email-verification/src/main/java/com/xtremand/email/verification/service/EmailVerificationChartService.java
@@ -4,6 +4,7 @@ import com.xtremand.domain.entity.User;
 import com.xtremand.email.verification.model.ChartDropdownRange;
 import com.xtremand.email.verification.model.ChartDropdownResponse;
 import com.xtremand.email.verification.model.dto.chart.ChartDataDto;
+import com.xtremand.common.exception.BadRequestException;
 import com.xtremand.email.verification.model.dto.chart.ChartDataResponseDto;
 import com.xtremand.email.verification.model.dto.chart.ChartRange;
 import com.xtremand.email.verification.repository.EmailVerificationHistoryRepository;
@@ -86,7 +87,50 @@ public class EmailVerificationChartService {
         return ranges;
     }
 
+    public void validateChartRange(ChartRange range) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new IllegalStateException("User is not authenticated.");
+        }
+
+        String userEmail = authentication.getName();
+        Optional<User> userOpt = userRepository.findByEmail(userEmail);
+        if (userOpt.isEmpty()) {
+            throw new BadRequestException("User not found.");
+        }
+
+        Long userId = userOpt.get().getId();
+        Optional<EmailVerificationHistoryRepository.DateRangeProjection> dateRangeOpt = historyRepository.findDateRangeByUserId(userId);
+
+        int requiredMonths = switch (range) {
+            case M1 -> 1;
+            case M3 -> 3;
+            case M6 -> 6;
+            case Y1 -> 12;
+            case Y3 -> 36;
+            case Y5 -> 60;
+        };
+
+        if (dateRangeOpt.isEmpty() || dateRangeOpt.get().getEarliest() == null) {
+            if (requiredMonths > 1) { // Only M1 is allowed if no data
+                throw new BadRequestException("Invalid range selected. No data available for this range.");
+            }
+            return;
+        }
+
+        Instant earliestInstant = dateRangeOpt.get().getEarliest();
+        ZonedDateTime earliestZoned = earliestInstant.atZone(ZoneId.systemDefault());
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+
+        long monthsOfData = ChronoUnit.MONTHS.between(earliestZoned, now);
+
+        if (monthsOfData + 1 < requiredMonths) {
+            throw new BadRequestException("You do not have enough data to view this range. Please select a shorter time frame.");
+        }
+    }
+
     public ChartDataResponseDto getChartData(ChartRange range) {
+        validateChartRange(range);
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String userEmail = authentication.getName();
         Instant startDate = calculateStartDate(range);

--- a/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/TestApplication.java
+++ b/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/TestApplication.java
@@ -1,0 +1,9 @@
+package com.xtremand.email.verification;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.xtremand")
+public class TestApplication {
+    // This class is intentionally left empty.
+    // It's used by Spring Boot tests to load the application context.
+}

--- a/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/controller/EmailVerificationChartControllerTest.java
+++ b/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/controller/EmailVerificationChartControllerTest.java
@@ -1,0 +1,74 @@
+package com.xtremand.email.verification.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.format.support.FormattingConversionService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.xtremand.common.exception.BadRequestException;
+import com.xtremand.common.exception.GlobalExceptionHandler;
+import com.xtremand.email.verification.converter.ChartRangeConverter;
+import com.xtremand.email.verification.model.dto.chart.ChartDataResponseDto;
+import com.xtremand.email.verification.model.dto.chart.ChartRange;
+import com.xtremand.email.verification.service.EmailVerificationChartService;
+
+@ExtendWith(MockitoExtension.class)
+public class EmailVerificationChartControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private EmailVerificationChartService chartService;
+
+    @InjectMocks
+    private EmailVerificationChartController chartController;
+
+    @BeforeEach
+    void setUp() {
+        FormattingConversionService conversionService = new FormattingConversionService();
+        conversionService.addConverter(new ChartRangeConverter());
+
+        mockMvc = MockMvcBuilders.standaloneSetup(chartController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setConversionService(conversionService)
+                .build();
+    }
+
+    @Test
+    @WithMockUser
+    void getChartData_withValidRange_shouldReturnOk() throws Exception {
+        when(chartService.getChartData(ChartRange.M1)).thenReturn(new ChartDataResponseDto(java.util.Collections.emptyList()));
+
+        mockMvc.perform(get("/api/v1/email/verify/chart/data")
+                        .param("range", "M1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void getChartData_withInvalidRange_shouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/email/verify/chart/data")
+                        .param("range", "INVALID_RANGE"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    void getChartData_withInvalidRange_shouldReturnBadRequest_whenServiceThrowsException() throws Exception {
+        when(chartService.getChartData(ChartRange.M3)).thenThrow(new BadRequestException("Invalid range"));
+
+        mockMvc.perform(get("/api/v1/email/verify/chart/data")
+                        .param("range", "M3"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/service/EmailVerificationChartServiceTest.java
+++ b/xtremand-backend/xtremand-email-verification/src/test/java/com/xtremand/email/verification/service/EmailVerificationChartServiceTest.java
@@ -1,26 +1,30 @@
 package com.xtremand.email.verification.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.xtremand.common.exception.BadRequestException;
 import com.xtremand.domain.entity.User;
 import com.xtremand.email.verification.model.ChartDropdownResponse;
+import com.xtremand.email.verification.model.dto.chart.ChartRange;
 import com.xtremand.email.verification.repository.EmailVerificationHistoryRepository;
 import com.xtremand.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithMockUser;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EmailVerificationChartServiceTest {
@@ -133,5 +137,70 @@ class EmailVerificationChartServiceTest {
 
         assertThat(ranges).hasSize(1);
         assertThat(ranges.get(0).getValue()).isEqualTo("1M");
+    }
+
+    @Test
+    void validateChartRange_shouldPass_whenRangeIsValid() {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+        Instant now = Instant.now();
+        Instant earliest = now.minus(40, ChronoUnit.DAYS);
+        when(historyRepository.findDateRangeByUserId(1L)).thenReturn(Optional.of(createDateRange(earliest, now)));
+
+        chartService.validateChartRange(ChartRange.M1);
+    }
+
+    @Test
+    void validateChartRange_shouldThrowBadRequest_whenRangeIsInvalid() {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+        Instant now = Instant.now();
+        Instant earliest = now.minus(20, ChronoUnit.DAYS);
+        when(historyRepository.findDateRangeByUserId(1L)).thenReturn(Optional.of(createDateRange(earliest, now)));
+
+        assertThatThrownBy(() -> chartService.validateChartRange(ChartRange.M3))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("You do not have enough data to view this range. Please select a shorter time frame.");
+    }
+
+    @Test
+    void validateChartRange_shouldPass_for1MonthRange_whenNoHistoryExists() {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+        when(historyRepository.findDateRangeByUserId(1L)).thenReturn(Optional.empty());
+
+        chartService.validateChartRange(ChartRange.M1);
+    }
+
+    @Test
+    void validateChartRange_shouldThrowBadRequest_for3MonthRange_whenNoHistoryExists() {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+        when(historyRepository.findDateRangeByUserId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chartService.validateChartRange(ChartRange.M3))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Invalid range selected. No data available for this range.");
+    }
+
+    @Test
+    void validateChartRange_shouldThrowBadRequest_whenUserNotFound() {
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chartService.validateChartRange(ChartRange.M1))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("User not found.");
+    }
+
+    @Test
+    void getChartData_shouldCallValidateChartRange() {
+        Instant fixedInstant = Instant.parse("2025-10-07T11:33:01.821423477Z");
+        try (MockedStatic<Instant> mockedInstant = Mockito.mockStatic(Instant.class)) {
+            mockedInstant.when(Instant::now).thenReturn(fixedInstant);
+
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(testUser));
+            Instant earliest = fixedInstant.minus(40, ChronoUnit.DAYS);
+            when(historyRepository.findDateRangeByUserId(1L)).thenReturn(Optional.of(createDateRange(earliest, fixedInstant)));
+
+            chartService.getChartData(ChartRange.M1);
+
+            verify(historyRepository).findChartDataByUserEmail("test@example.com", fixedInstant.minus(30, ChronoUnit.DAYS), "IYYY-IW");
+        }
     }
 }


### PR DESCRIPTION
The range value for the chart dropdown is now validated to prevent invalid values from being processed. A new validation method has been added to the `EmailVerificationChartService` to check if the user has enough data for the selected range. The `GlobalExceptionHandler` has been updated to handle `BadRequestException`, and the tests have been updated to cover the new validation logic.